### PR TITLE
Do not escape tildes in safe constructs that are nested in unsafe constructs

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,28 @@ export const gfmStrikethroughFromMarkdown = {
   exit: {strikethrough: exitStrikethrough}
 }
 
+/**
+ * List of constructs that occur in phrasing (paragraphs, headings), but cannot
+ * contain strikethroughs. So they sort of cancel each other out.
+ */
+const constructsWithoutStrikethrough = [
+  'autolink',
+  'destinationLiteral',
+  'destinationRaw',
+  'reference',
+  'titleQuote',
+  'titleApostrophe'
+]
+
 /** @type {ToMarkdownExtension} */
 export const gfmStrikethroughToMarkdown = {
-  unsafe: [{character: '~', inConstruct: 'phrasing'}],
+  unsafe: [
+    {
+      character: '~',
+      inConstruct: 'phrasing',
+      notInConstruct: constructsWithoutStrikethrough
+    }
+  ],
   handlers: {delete: handleDelete}
 }
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ export const gfmStrikethroughFromMarkdown = {
 /**
  * List of constructs that occur in phrasing (paragraphs, headings), but cannot
  * contain strikethroughs. So they sort of cancel each other out.
+ *
+ * Note: keep in sync with: <https://github.com/syntax-tree/mdast-util-to-markdown/blob/c47743b/lib/unsafe.js#L11>
  */
 const constructsWithoutStrikethrough = [
   'autolink',

--- a/test.js
+++ b/test.js
@@ -93,5 +93,101 @@ test('mdast -> markdown', (t) => {
     'should serialize strikethrough w/ eols'
   )
 
+  t.equal(
+    toMarkdown(
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'link',
+            url: '~a',
+            children: []
+          }
+        ]
+      },
+      {extensions: [gfmStrikethroughToMarkdown]}
+    ),
+    '[](~a)\n',
+    'should not escape tildes in a `destinationLiteral`'
+  )
+
+  t.equal(
+    toMarkdown(
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'link',
+            url: '~a',
+            children: [{type: 'text', value: 'link text'}]
+          }
+        ]
+      },
+      {extensions: [gfmStrikethroughToMarkdown]}
+    ),
+    '[link text](~a)\n',
+    'should not escape tildes in a `destinationRaw`'
+  )
+
+  t.equal(
+    toMarkdown(
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'linkReference',
+            identifier: '~a',
+            referenceType: 'full',
+            children: []
+          }
+        ]
+      },
+      {extensions: [gfmStrikethroughToMarkdown]}
+    ),
+    '[][~a]\n',
+    'should not escape tildes in a `reference`'
+  )
+
+  t.equal(
+    toMarkdown(
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'link',
+            url: '#',
+            title: '~a',
+            children: []
+          }
+        ]
+      },
+      {extensions: [gfmStrikethroughToMarkdown]}
+    ),
+    '[](# "~a")\n',
+    'should not escape tildes in a `title` (double quotes)'
+  )
+
+  t.equal(
+    toMarkdown(
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'link',
+            url: '#',
+            title: '~a',
+            children: []
+          }
+        ]
+      },
+      {
+        quote: "'",
+        extensions: [gfmStrikethroughToMarkdown]
+      }
+    ),
+    "[](# '~a')\n",
+    'should not escape tildes in a `title` (single quotes)'
+  )
+
   t.end()
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Fix for the issue described in https://github.com/remarkjs/remark-gfm/issues/42

I've first added tests to prove that tildes are in fact being escaped in some safe constructs like link URLs (among others). See the results here: https://github.com/bertramakers/mdast-util-gfm-strikethrough/actions/runs/3394305801

Results with the code fix: https://github.com/bertramakers/mdast-util-gfm-strikethrough/actions/runs/3394322969

Tests & code are heavily based on https://github.com/syntax-tree/mdast-util-to-markdown/commit/7b381da5bceee3c36be079e27a2bad7b3cc412c2 so credits go to @wooorm for doing the heavy lifting before and sharing how to fix this.

<!--do not edit: pr-->
