### PR TITLE
perf: pre-declare position on delete factory

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,10 @@ export function gfmStrikethroughToMarkdown() {
  * @type {FromMarkdownHandle}
  */
 function enterStrikethrough(token) {
-  this.enter({type: 'delete', children: []}, token)
+  // Trailing `position: undefined` keeps the delete hidden class stable;
+  // mdast-util-from-markdown's enter() patches the field to a real value,
+  // but the property already exists, so no shape transition fires.
+  this.enter({type: 'delete', children: [], position: undefined}, token)
 }
 
 /**


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Problem: the strikethrough handler creates each delete node as a
fresh object literal, then mdast-util-from-markdown's enter() sets
node.position afterwards. V8 treats that late assignment as a shape
change, so every delete node walks through two hidden classes instead
of one. Core nodes already avoid this by declaring position up front;
without the same trick on extension nodes, GFM trees end up mixing
two layouts and downstream tree walks lose monomorphic dispatch.

Goal: declare position on the delete literal at construction so V8
keeps a single hidden class for delete from start to finish.

Changes:
- lib/index.js: trailing position: undefined on the delete literal
  in enterStrikethrough.

Notes: pairs with the matching core change in
https://github.com/syntax-tree/mdast-util-from-markdown/pull/53;
merged on its own this branch is a no-op. Validated with npm test
(build, format, 100% coverage, 13 of 13 tests in dev and prod).

Bench (local harness, 3-run median-of-medians, GFM tokenizer and
mdast extensions stacked). Numbers below are the parse time delta
versus an unmodified upstream main; positive numbers mean slower,
negative numbers mean faster.

Input: one paragraph of 1000 ~~strike~~ runs. On the baseline this
scenario carries the second-largest mdast-layer share in the GFM
corpus (full 11.0 ms, tokenize-only 5.2 ms; the mdast layer is the
gap between those two).

Effect of pairing this branch with PR #53:

- PR #53 alone, extensions on upstream main: 14.6 percent slower.
  Trees mix two layouts because delete nodes still take a shape
  change when position is patched in, so downstream tree-walk call
  sites go polymorphic.
- PR #53 with this branch alongside (and the three sibling extension
  branches): 2.6 percent slower, which sits inside the bench's drift
  floor of 4 to 12 percent (main vs main with no code change in the
  same window).

The paired configuration recovers about 12 percentage points relative
to PR #53 on its own. Without this branch, PR #53 would appear to
regress strikethrough-heavy parses; with it, the parse runs roughly
as fast as upstream main does today.

<!--do not edit: pr-->
